### PR TITLE
fix(core): do not display treeview frame on login page

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -563,4 +563,18 @@ class PluginTreeviewConfig  extends CommonDBTM {
          echo "d.openTo(" .$nodes[count($nodes)-1]. ");\n";
       }
    }
+
+
+   /**
+    * Make sure that GLPI index page location is on top of window hierarchy
+    */
+   public static function loginPageToTop() {
+      echo HTML::scriptBlock("
+      $(document).ready(
+         function() {
+            if (top != self)
+               top.location = self.location;
+         });
+      ");
+   }
 }

--- a/setup.php
+++ b/setup.php
@@ -100,6 +100,15 @@ function plugin_init_treeview() {
    if (Session::haveRight("config", UPDATE) || Session::haveRight("profile", UPDATE)) {
       $PLUGIN_HOOKS['config_page']['treeview'] = 'front/config.form.php';
    }
+
+
+   $currentPage =  explode("/", $_SERVER['PHP_SELF']);
+   if (array_pop($currentPage) == "index.php") {
+      $PLUGIN_HOOKS['display_login']['treeview'] = [
+         "PluginTreeviewConfig",
+         "loginPageToTop"
+      ];
+   }
 }
 
 

--- a/setup.php
+++ b/setup.php
@@ -101,7 +101,6 @@ function plugin_init_treeview() {
       $PLUGIN_HOOKS['config_page']['treeview'] = 'front/config.form.php';
    }
 
-
    $currentPage =  explode("/", $_SERVER['PHP_SELF']);
    if (array_pop($currentPage) == "index.php") {
       $PLUGIN_HOOKS['display_login']['treeview'] = [


### PR DESCRIPTION

Do not display treeview frame on login page (when logout)

Before

![image](https://user-images.githubusercontent.com/7335054/120431382-b3810100-c378-11eb-8a6a-dbfe14a0d00e.png)

After

![image](https://user-images.githubusercontent.com/7335054/120431416-bf6cc300-c378-11eb-96a7-9f551f48eeec.png)
