### PR TITLE
fix config page breadcrumbs

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -35,26 +35,12 @@ $config = new PluginTreeviewConfig();
 if (isset($_POST["update"])) {
    $config->update($_POST);
    Html::back();
-
 } else {
-
    if (Plugin::isPluginActive("treeview")) {
-
-      Html::header(PluginTreeviewConfig::getTypeName(),
-                $_SERVER['PHP_SELF'],
-                "plugins",
-                "plugintreeviewpreference",
-                "config");
+      Html::header(PluginTreeviewConfig::getTypeName(), $_SERVER['PHP_SELF'], "config", "plugin");
       $config->showForm(1);
-
    } else {
-
-      Html::header(__('Setup'),
-                $_SERVER['PHP_SELF'],
-                "plugins",
-                "plugintreeviewpreference",
-                "config");
-
+      Html::header(__('Setup'), $_SERVER['PHP_SELF'], "config", "plugin");
       // Get the configuration from the database and show it
       echo " <script type='text/javascript'>
          if (top != self)


### PR DESCRIPTION
Fixes #44

The config page only seems to be accessible from the Plugins list, so the breadcrumbs could be changed to link to the plugins page. Right now, it links to the Plugins menu which this plugin doesn't use, and not many other plugins use it either. So, while it would show "Plugins" in the breadcrumbs, it would link to the homepage.