### PR TITLE
fix: tree not displayed

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -357,8 +357,7 @@ class PluginTreeviewConfig  extends CommonDBTM {
                'WHERE' => [
                   'level' => $n,
                   'locations_id' => $nodes[$n-1],
-                   getEntitiesRestrictCriteria('glpi_locations', '', '', true)
-               ],
+               ] + getEntitiesRestrictCriteria('glpi_locations', '', '', true),
                'ORDER' => ['completename ASC']
             ]);
 


### PR DESCRIPTION
The tree is not displayed, generating an error in SQL logs:

```
glpisqllog.ERROR: DBmysql::query() in /home/ubuntu/Dev/GLPI/10.0-bugfixes/src/DBmysql.php line 379
  *** MySQL query error:
  SQL: SELECT * FROM `glpi_locations` WHERE `level` = '1' AND `locations_id` = '0' AND () ORDER BY `completename` ASC
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') ORDER BY `completename` ASC' at line 1
  Backtrace :
  src/DBmysqlIterator.php:112                        
  src/DBmysql.php:1078                               DBmysqlIterator->execute()
  plugins/treeview/inc/config.class.php:356          DBmysql->request()
  plugins/treeview/inc/config.class.php:276          PluginTreeviewConfig->getNodesFromDb()
  plugins/treeview/left.php:58                       PluginTreeviewConfig->buildTreeview()
```

This is not systematic; I was able to reproduce it only once on 1st use.
